### PR TITLE
Fix dependency name on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This is a Crystal library providing an APM tracing client for [Datadog](https://
 
    ```yaml
    dependencies:
-     datadog_trace:
+     datadog:
        github: jgaskins/datadog
    ```
 


### PR DESCRIPTION
Hi 👋  - First of all, thank you for creating this lib/shard ❤️ 

This is my first time working with Crystal so I'm not sure if this error is expected or not when installing datadog and running `shards install`:

```
Error shard name (datadog) doesn't match dependency name (datadog_trace)
```

I fixed it renaming `datadog_trace` to `datadog` only

Feel free to close this PR if it does not make sense 😅 


